### PR TITLE
Add a typescript build step to test-unit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ defaults_Dependencies: &defaults_Dependencies |
     apk --no-cache add bash
     apk add --no-cache -t build-dependencies make gcc g++ python libtool autoconf automake
     npm config set unsafe-perm true
-    npm install -g node-gyp
+    npm install -g node-gyp typescript
 
 defaults_Typescript: &defaults_Typescript |
     npm run build
@@ -93,6 +93,9 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
+      - run:
+          name: Compile typescript
+          command: *defaults_Typescript
       - run:
           name: Install tape, tapes and tap-xunit
           command: npm install tape tapes tap-xunit tap-spec nyc

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-health",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-health",
-  "version": "7.3.0",
+  "version": "7.3.1",
   "description": "Shared code for generic health check servers",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
The last snapshot build failed to build the typescript.

This PR fixes the build step in circleci by installing typescript, and also runs the tsc during the `test-unit` step so this doesn't happen again.